### PR TITLE
调整 Gradle 引用变量方式

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -63,8 +63,8 @@
                 // 如果version以SNAPSHOT结尾就会上传到快照仓库，如果不是就上传到release仓库
                 url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
                 credentials {
-                    username = "${NEXUS_USERNAME}"
-                    password = "${NEXUS_PASSWORD}"
+                    username = project.properties.NEXUS_USERNAME
+                    password = project.properties.NEXUS_PASSWORD
                 }
             }
 


### PR DESCRIPTION
修复 Gradle 脚本中使用了个人环境定义的变量，导致其他环境无法直接构建项目的问题